### PR TITLE
ci(release-action): Fixed release action to run on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,31 +1,31 @@
 name: Release
 
 # Create a release on successful PR into master
-on: 
+on:
   pull_request:
     branches:
-      - master  
+      - master
 
 jobs:
   # Build the app
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
-    
+
     # Checkout the repo
     - uses: actions/checkout@v1
-    
+
     # Set up node.js
     - name: Use Node.js 10
       uses: actions/setup-node@v1
       with:
         node-version: '10.x'
         registry-url: 'https://registry.npmjs.org'
-    
+
     # Install dependencies
     - name: Install node.js dependencies
       run: npm install
-      
+
     # Build the app
     - name: Build - Windows
       run: npm run electron:windows


### PR DESCRIPTION
Electron builder should run on Windows so a Windows and Linux build can be created.